### PR TITLE
Fix : prepend '.' to attr snippet

### DIFF
--- a/snippets/attr.cson
+++ b/snippets/attr.cson
@@ -1,4 +1,4 @@
 ".source.js":
     "attr":
         prefix: "attr"
-        body: "attr('${1:}', '${2:}')"
+        body: ".attr('${1:}', '${2:}')"


### PR DESCRIPTION
Prepend `.` to  `"attr('${1:}', '${2:}')"` 
